### PR TITLE
fixed doc name to always uppcase for classroom

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -106,8 +106,11 @@ export default function AdminPage() {
     const updateLog = (message: string) => setLog(prev => [...prev, message]);
 
     try {
-        updateLog(`Querying for existing students in Grade ${values.grade} Section ${values.section}...`);
-        const studentsQuery = query(collection(db, 'students'), where('class', '==', values.grade), where('section', '==', values.section));
+        const grade = values.grade;
+        const section = values.section.toUpperCase();
+        
+        updateLog(`Querying for existing students in Grade ${grade} Section ${section}...`);
+        const studentsQuery = query(collection(db, 'students'), where('class', '==', grade), where('section', '==', section));
         const querySnapshot = await getDocs(studentsQuery);
 
         let lastRollNumber = 0;
@@ -125,8 +128,8 @@ export default function AdminPage() {
 
         for (let i = 0; i < values.count; i++) {
             const rollNumber = lastRollNumber + i + 1;
-            const email = `student${values.grade}${values.section}_${rollNumber}@example.com`;
-            const password = `student${values.grade}${values.section}_${rollNumber}`;
+            const email = `student${grade}${section}_${rollNumber}@example.com`;
+            const password = `student${grade}${section}_${rollNumber}`;
             const name = `Student ${rollNumber}`;
             
             try {
@@ -139,14 +142,14 @@ export default function AdminPage() {
                 const userCredential = await createUserWithEmailAndPassword(tempAuth, email, password);
                 const user = userCredential.user;
 
-                const classroomId = `${values.grade}-${values.section}`;
+                const classroomId = `${grade}-${section}`.toUpperCase();
                 const studentData = {
                     uid: user.uid,
                     email,
                     name,
                     role: 'student',
-                    class: values.grade,
-                    section: values.section,
+                    class: grade,
+                    section: section,
                     rollNumber: String(rollNumber),
                     dev_generated: true,
                     classroomId: classroomId,
@@ -158,8 +161,8 @@ export default function AdminPage() {
                 // Add student to classroom
                 const classroomRef = doc(db, 'classrooms', classroomId);
                 await setDoc(classroomRef, {
-                    grade: values.grade,
-                    section: values.section,
+                    grade: grade,
+                    section: section,
                     studentIds: arrayUnion(user.uid)
                 }, { merge: true });
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -91,17 +91,19 @@ export default function SignupPage() {
       const collectionName = values.role === 'teacher' ? 'teachers' : 'students';
       
       if (values.role === 'student') {
-          const classroomId = `${values.class}-${values.section}`;
-          userData.class = values.class;
-          userData.section = values.section;
+          const grade = values.class!;
+          const section = values.section!.toUpperCase();
+          const classroomId = `${grade}-${section}`.toUpperCase();
+          userData.class = grade;
+          userData.section = section;
           userData.rollNumber = values.rollNumber;
           userData.classroomId = classroomId;
 
           // Add student to classroom
           const classroomRef = doc(db, 'classrooms', classroomId);
           await setDoc(classroomRef, {
-              grade: values.class,
-              section: values.section,
+              grade: grade,
+              section: section,
               studentIds: arrayUnion(user.uid)
           }, { merge: true });
       }


### PR DESCRIPTION
---
name: Pull Request
about: Propose a change to the codebase.
title: "[Type]: Brief description of changes"
labels: ''
assignees: ''

---

## Description
Currently the name of the document of collection "classrooms" is case-sensitive, i.e., both "10-A" and "10-a" can exist at the same time. This should be fixed so that the document name is always in uppercase.


## Related Issue
Fixes #25 

## Type of Change

Please check the box that applies to your change:

- [X] 🐞 **Bug fix** (a non-breaking change that fixes an issue)
- [ ] ✨ **New feature** (a non-breaking change that adds functionality)
- [ ] 💥 **Breaking change** (a fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 **Documentation update**
- [ ] 🎨 **Style change** (formatting, renaming, etc.)
- [ ] ♻️ **Refactor** (a code change that neither fixes a bug nor adds a feature)
- [ ] ⚙️ **Build/CI/CD** (changes to our build process or CI configuration)

## Checklist

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
