### PR TITLE
[Bugfix]: Make logout notification background white for better visibility

### DIFF
--- a/src/components/nav-items.tsx
+++ b/src/components/nav-items.tsx
@@ -47,6 +47,7 @@ export function NavItems() {
         variant: 'destructive',
         title: 'Logout Failed',
         description: 'An unexpected error occurred during logout.',
+        style: { backgroundColor: "#fff", color: "#222" } // Set background to white, text to dark
       });
     }
   };

--- a/src/components/nav-items.tsx
+++ b/src/components/nav-items.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
@@ -37,8 +36,10 @@ export function NavItems() {
       }
       router.push('/login');
       toast({
+          variant: 'success',
           title: "Logged Out",
-          description: "You have been successfully logged out."
+          description: "You have been successfully logged out.",
+          style: { backgroundColor: "#fff", color: "#222" } // Set background to white, text to dark
       });
     } catch (error) {
       console.error("Error signing out: ", error);


### PR DESCRIPTION
---
name: Pull Request
title: "[Bug]: Logout notification not visible due to low contrast with page background"
labels: ''
assignees: ''

---

## Description

Changed the logout notification background color to white for improved visibility and readability. This was done by passing a style prop to the toast notifications in `nav-items.tsx`

## Related Issue

Closes #35 

## Type of Change

Please check the box that applies to your change:

- [ ] 🐞 **Bug fix** (a non-breaking change that fixes an issue)

## How Has This Been Tested?

Logged in and triggered a logout to verify the notification background is now white and stands out against the main page background.

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
